### PR TITLE
Reduce required go version to 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/foxglove/go-rosbag
 
-go 1.21
+go 1.18
 
 require (
 	github.com/pierrec/lz4/v4 v4.1.18


### PR DESCRIPTION
Nothing in the lib strictly requires 1.21. Using 1.18 will make it compatible with more consumers.