### PR TITLE
Upgrade go-rosbag to 1.20

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - name:  install go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.20.x
       - name: install golangci-lint
         run:
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
@@ -27,7 +27,7 @@ jobs:
       - name:  install go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.20.x
       - name: checkout code
         uses: actions/checkout@v3
       - name: run tests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/foxglove/go-rosbag
 
-go 1.18
+go 1.20
 
 require (
 	github.com/pierrec/lz4/v4 v4.1.18


### PR DESCRIPTION
This downgrades the version running in CI and upgrades the one required by the lib, to 1.20.