### PR TITLE
Convert index data time to rostime on bag write

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -291,7 +291,7 @@ func (b *Writer) writeIndexData(indexData IndexData) error {
 	data := make([]byte, 12*len(indexData.Data))
 	offset := 0
 	for _, entry := range indexData.Data {
-		offset += putU64(data[offset:], entry.Time)
+		offset += putRostime(data[offset:], entry.Time)
 		offset += putU32(data[offset:], entry.Offset)
 	}
 


### PR DESCRIPTION
The reader converts index data time from `rostime` [here](https://github.com/foxglove/go-rosbag/blob/main/parse.go#L139). However, the writer does not convert it to `rostime`.