### PR TITLE
linear iterator: fix bz2 iteration

### DIFF
--- a/linear_iterator.go
+++ b/linear_iterator.go
@@ -94,6 +94,7 @@ func (it *linearIterator) Next() (*Connection, *Message, error) {
 				continue
 			case CompressionBZ2:
 				it.reader.Reset(bzip2.NewReader(bytes.NewReader(chunkData)))
+				it.inChunk = true
 			default:
 				return nil, nil, ErrUnsupportedCompression{string(compression)}
 			}


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

For bags with bz2 compression that are not indexed, the linear iterator mistakenly fails too early with EOF. This is because we weren't resetting `inChunk` for bz2 bags only.

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->


<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

